### PR TITLE
Fix a bug: printing emoji encoded with utf-8

### DIFF
--- a/instapy/instapy.py
+++ b/instapy/instapy.py
@@ -1331,7 +1331,7 @@ class InstaPy:
                             already_liked += 1
                     else:
                         self.logger.info(
-                            '--> Image not liked: {}'.format(reason.encode('utf-8')))
+                            '--> Image not liked: {}'.format(reason))
                         inap_img += 1
                 except NoSuchElementException as err:
                     self.logger.error('Invalid Page: {}'.format(err))


### PR DESCRIPTION
When there is an emoji in an inappropriate tag, the app crashes. Now it is fixed.

Picture of the bug:
![image](https://user-images.githubusercontent.com/9549288/43033137-1eeaf198-8ccd-11e8-80c4-2f9abc34d962.png)

closes #1830, #2271.